### PR TITLE
Add hash to class names in development, use hash only in production

### DIFF
--- a/addon/keyframes.js
+++ b/addon/keyframes.js
@@ -51,7 +51,12 @@ exports.addon = function (renderer, config) {
     };
 
     renderer.keyframes = function (keyframes, block) {
-        if (!block) block = renderer.hash(keyframes);
+        if (process.env.NODE_ENV === 'production') {
+            block = renderer.hash(css);
+        } else {
+            block = (block || '') + '_' + renderer.hash(css);
+        }
+        
         block = renderer.pfx + block;
 
         renderer.putAt('', keyframes, '@keyframes ' + block);

--- a/addon/rule.js
+++ b/addon/rule.js
@@ -6,9 +6,12 @@ exports.addon = function (renderer) {
     }
 
     renderer.rule = function (css, block) {
-        block = block || renderer.hash(css);
-        block = renderer.pfx + block;
-        renderer.put('.' + block, css);
+        if (process.env.NODE_ENV === 'production') {
+            block = renderer.hash(css);
+        } else {
+            block = (block || '') + '_' + renderer.hash(css);
+        }
+        renderer.put('.' + renderer.pfx + block, css);
 
         return ' ' + block;
     };

--- a/addon/sheet.js
+++ b/addon/sheet.js
@@ -8,8 +8,10 @@ exports.addon = function (renderer) {
     renderer.sheet = function (map, block) {
         var result = {};
 
-        if (!block) {
-            block = renderer.hash(map);
+        if (process.env.NODE_ENV === 'production') {
+            block = renderer.hash(css);
+        } else {
+            block = (block || '') + '_' + renderer.hash(css);
         }
 
         var onElementModifier = function (elementModifier) {

--- a/addon/spread.js
+++ b/addon/spread.js
@@ -6,7 +6,12 @@ exports.addon = function (renderer) {
     }
 
     renderer.spread = function (css, block) {
-        block = block || renderer.hash(css);
+        if (process.env.NODE_ENV === 'production') {
+            block = renderer.hash(css);
+        } else {
+            block = (block || '') + '_' + renderer.hash(css);
+        }
+        
         block = renderer.pfx + block;
         renderer.put('.' + block + ',[data-' + block + ']', css);
 

--- a/index.js
+++ b/index.js
@@ -7,7 +7,7 @@ var hash = function (str) {
 
     while (i) hash = (hash * 33) ^ str.charCodeAt(--i);
 
-    return '_' + (hash >>> 0).toString(36);
+    return (hash >>> 0).toString(36);
 };
 
 exports.create = function (config) {


### PR DESCRIPTION
Changes production to generate class names based purely on the hash, not using the display name. I believe this is the more common behavior as it creates smaller stylesheets with less leaking of internal names.

Also changes class names in development to append the hash of the rules. This has two benefits:

- Avoids the pitfall where everything breaks if you accidentally use the same name for two rules.
- Helps debug production by showing you in development what the rules hash to.