### PR TITLE
chore: no sense to test it @ node 8.x since it is a far legacy.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2
 refs:
   container: &container
     docker:
-      - image: circleci/node:8.11@sha256:af0ffb60afc34736f30fd8ce6662175ca29009835308fb7786e27ecfce424f20
+      - image: circleci/node:12.20.1
     working_directory: ~/repo
 
 jobs:

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -1,6 +1,6 @@
 name: Node CI
 
-on: [push]
+on: [push, pull_request]
 
 jobs:
   build:

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -9,7 +9,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [8.x, 10.x, 12.x]
+        node-version: [10, 12, 14]
 
     steps:
     - uses: actions/checkout@v1


### PR DESCRIPTION
ATM im thinking that 10.x is also obsolete and should be removed.

Now testing at 10, 12, 14.

Also added GH Actions to test PRs