### PR TITLE
remove redundant _ prefix from hash()

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,7 +7,7 @@ var hash = function (str) {
 
     while (i) h = (h * 33) ^ str.charCodeAt(--i);
 
-    return '_' + (h >>> 0).toString(36);
+    return (h >>> 0).toString(36);
 };
 
 exports.create = function (config) {


### PR DESCRIPTION
Since `renderer.pfx` is also `_`, this was resulting in a `.__` prefix on all classnames. Not a huge deal, but we can save bytes!