### PR TITLE
remove hydration logging in dev

### DIFF
--- a/addon/hydrate.js
+++ b/addon/hydrate.js
@@ -20,14 +20,7 @@ exports.addon = function (renderer) {
         var put = renderer.put;
 
         renderer.put = function (selector, css) {
-            if (selector in hydrated) {
-                if (process.env.NODE_ENV !== 'production') {
-                    // eslint-disable-next-line
-                    console.info('Hydrated selector: ' + selector);
-                }
-
-                return;
-            }
+            if (selector in hydrated) return;
 
             put(selector, css);
         };


### PR DESCRIPTION
Looks like this was added [way back](https://github.com/streamich/nano-css/pull/6). Are y'all open to removal?

I'm using nano-css via [hypostyle](https://github.com/sure-thing/hypostyle) in a Next.js site and during dev this is 1) generating 100s-1000s of lines in the console 2) making it hard to view my own debugging logs and 3) I think actually slowing down my browser after a few dozen HMR cycles.