### PR TITLE
chore: switch to safe-stable-stringify

### DIFF
--- a/addon/stable.js
+++ b/addon/stable.js
@@ -1,6 +1,7 @@
 'use strict';
 
-var stringify = require('fastest-stable-stringify');
+var configure = require('safe-stable-stringify').configure;
+var stringify = configure({ bigint: false });
 
 exports.addon = function (renderer) {
     renderer.stringify = stringify;

--- a/docs/stable.md
+++ b/docs/stable.md
@@ -1,7 +1,7 @@
 # `stable` Addon
 
 When generating class names, `nano-css` stringifies CSS-like objects to compute a hash and generate a unique class name. By default it uses `JSON.stringify`, which is not stable. This
-addon makes `nano-css` use [`fastest-stable-stringify`](https://github.com/streamich/fastest-stable-stringify)
+addon makes `nano-css` use [`safe-stable-stringify`](https://github.com/BridgeAR/safe-stable-stringify)
 to generate fast predictable hashes across JavaScript runtimes.
 
 ## Installation

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
   "dependencies": {
     "css-tree": "^1.1.2",
     "csstype": "^3.0.6",
-    "fastest-stable-stringify": "^2.0.2",
+    "safe-stable-stringify": "^2.2.0",
     "inline-style-prefixer": "^6.0.0",
     "rtl-css-js": "^1.14.0",
     "sourcemap-codec": "^1.4.8",


### PR DESCRIPTION
This replaces the `fastest-stable-stringify` with
`safe-stable-stringify` for performance reasons. There is no behavior
change.

fastest-stable-stringify x 17,945 ops/sec ±2.92% (84 runs sampled)
safe-stable-stringify x 24,922 ops/sec ±2.78% (82 runs sampled)