### PR TITLE
chore: delete unpkg default path in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,6 @@
   "version": "5.3.4",
   "description": "Smallest 5th gen CSS-in-JS library",
   "main": "index.js",
-  "unpkg": "dist/nano-css.umd.min.js",
   "types": "index.d.ts",
   "typings": "index.d.ts",
   "repository": {


### PR DESCRIPTION
Remove field 'unpkg' in package.json since the file "dist/nano-css.umd.min.js" does not exist. 
This non-existent file caused some custom parsers to not parse correctly.