### PR TITLE
fix: fixed types when skipLibCheck is set to false

### DIFF
--- a/addon/array.d.ts
+++ b/addon/array.d.ts
@@ -2,4 +2,4 @@ import {NanoRenderer} from '../types/nano';
 
 export interface ArrayAddon {}
 
-export function addon(nano: NanoRenderer);
+export function addon(nano: NanoRenderer): any;

--- a/addon/atoms.d.ts
+++ b/addon/atoms.d.ts
@@ -240,4 +240,4 @@ export interface Atoms {
     tr?: CSS.Property.Transform;
 }
 
-export function addon(nano: NanoRenderer);
+export function addon(nano: NanoRenderer): any;

--- a/addon/cache.d.ts
+++ b/addon/cache.d.ts
@@ -5,4 +5,4 @@ export interface CacheAddon {
     cache(css: CssLikeObject): string;
 }
 
-export function addon(nano: NanoRenderer);
+export function addon(nano: NanoRenderer): any;

--- a/addon/component.d.ts
+++ b/addon/component.d.ts
@@ -1,7 +1,7 @@
 import {NanoRenderer} from '../types/nano';
 
 export interface ComponentAddon {
-    Component;
+    Component: any;
 }
 
-export function addon(nano: NanoRenderer);
+export function addon(nano: NanoRenderer): any;

--- a/addon/cssom.d.ts
+++ b/addon/cssom.d.ts
@@ -14,4 +14,4 @@ export interface CSSOMAddon {
     createRule(selector: string, prelude?: string): CSSOMRule;
 }
 
-export function addon(nano: NanoRenderer);
+export function addon(nano: NanoRenderer): any;

--- a/addon/decorator.d.ts
+++ b/addon/decorator.d.ts
@@ -1,7 +1,7 @@
 import {NanoRenderer} from '../types/nano';
 
 export interface DecoratorAddon {
-    css;
+    css: any;
 }
 
-export function addon(nano: NanoRenderer);
+export function addon(nano: NanoRenderer): any;

--- a/addon/drule.d.ts
+++ b/addon/drule.d.ts
@@ -5,4 +5,4 @@ export interface DruleAddon {
     drule: (css: CssLikeObject, block?: string) => TDynamicCss;
 }
 
-export function addon(nano: NanoRenderer);
+export function addon(nano: NanoRenderer): any;

--- a/addon/dsheet.d.ts
+++ b/addon/dsheet.d.ts
@@ -5,4 +5,4 @@ export interface DsheetAddon {
     dsheet(map: object, block?: string): object;
 }
 
-export function addon(nano: NanoRenderer);
+export function addon(nano: NanoRenderer): any;

--- a/addon/emmet.d.ts
+++ b/addon/emmet.d.ts
@@ -611,4 +611,4 @@ export interface EmmetAddon {
     us?: CSS.Property.UserSelect;
 }
 
-export function addon(nano: NanoRenderer);
+export function addon(nano: NanoRenderer): any;

--- a/addon/extract.d.ts
+++ b/addon/extract.d.ts
@@ -2,4 +2,4 @@ import {NanoRenderer} from '../types/nano';
 
 export interface ExtractAddon {}
 
-export function addon(nano: NanoRenderer);
+export function addon(nano: NanoRenderer): any;

--- a/addon/global.d.ts
+++ b/addon/global.d.ts
@@ -2,7 +2,7 @@ import {NanoRenderer} from '../types/nano';
 import {CssLikeObject} from '../types/common';
 
 export interface GlobalAddon {
-    global(css: CssLikeObject);
+    global(css: CssLikeObject): any;
 }
 
-export function addon(nano: NanoRenderer);
+export function addon(nano: NanoRenderer): any;

--- a/addon/googleFont.d.ts
+++ b/addon/googleFont.d.ts
@@ -2,7 +2,7 @@ import {NanoRenderer} from '../types/nano';
 import {CssLikeObject} from '../types/common';
 
 export interface GoogleFontAddon {
-    googleFont(font: string, weights: number | string | (number | string)[], subsets: string | string[]);
+    googleFont(font: string, weights: number | string | (number | string)[], subsets: string | string[]): any;
 }
 
-export function addon(nano: NanoRenderer);
+export function addon(nano: NanoRenderer): any;

--- a/addon/hydrate.d.ts
+++ b/addon/hydrate.d.ts
@@ -1,7 +1,7 @@
 import {NanoRenderer} from '../types/nano';
 
 export interface HydrateAddon {
-    hydrate(sh: HTMLStyleElement);
+    hydrate(sh: HTMLStyleElement): any;
 }
 
-export function addon(nano: NanoRenderer);
+export function addon(nano: NanoRenderer): any;

--- a/addon/keyframes.d.ts
+++ b/addon/keyframes.d.ts
@@ -31,4 +31,4 @@ export interface KeyframesAddon {
     keyframes: (frames: object, block?: string) => string;
 }
 
-export function addon(nano: NanoRenderer);
+export function addon(nano: NanoRenderer): any;

--- a/addon/prefixer.d.ts
+++ b/addon/prefixer.d.ts
@@ -1,5 +1,5 @@
 import {NanoRenderer} from '../types/nano';
 
-export interface AmpAddon {}
+export interface PrefixerAddon {}
 
 export function addon(nano: NanoRenderer): any;

--- a/addon/rule.d.ts
+++ b/addon/rule.d.ts
@@ -23,4 +23,4 @@ export interface RuleAddon {
     rule: (css: CssLikeObject, block?: string) => string;
 }
 
-export function addon(nano: NanoRenderer);
+export function addon(nano: NanoRenderer): any;

--- a/addon/sheet.d.ts
+++ b/addon/sheet.d.ts
@@ -19,4 +19,4 @@ export interface SheetAddon {
     sheet: (cssMap: {[s: string]: CssLikeObject}, block?: string) => {[s: string]: string};
 }
 
-export function addon(nano: NanoRenderer);
+export function addon(nano: NanoRenderer): any;

--- a/addon/units.d.ts
+++ b/addon/units.d.ts
@@ -86,4 +86,4 @@ export interface UnitsAddon extends Units {
     units: Units;
 }
 
-export function addon(nano: NanoRenderer);
+export function addon(nano: NanoRenderer): any;

--- a/addon/vcssom.d.ts
+++ b/addon/vcssom.d.ts
@@ -15,13 +15,13 @@ export interface VRule {
      * Re-render css rule according to new CSS declarations.
      * @param decl CSS declarations, like `{color: 'red'}`
      */
-    diff(decl: CssProps);
+    diff(decl: CssProps): any;
 
     /**
      * Removes this `VRule` from CSSOM. After calling this method, you
      * cannot call `diff` anymore as this rule will be removed from style sheet.
      */
-    del();
+    del(): any;
 }
 
 export interface VSheet {
@@ -61,7 +61,7 @@ export interface VSheet {
      *
      * @param css CSS-like object with media queries as top level.
      */
-    diff(css: Css);
+    diff(css: Css): any;
 }
 
 export interface VCSSOMAddon {
@@ -69,4 +69,4 @@ export interface VCSSOMAddon {
     VSheet: new () => VSheet;
 }
 
-export function addon(nano: NanoRenderer);
+export function addon(nano: NanoRenderer): any;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nano-css",
-  "version": "5.3.5",
+  "version": "5.3.6",
   "description": "Smallest 5th gen CSS-in-JS library",
   "main": "index.js",
   "types": "index.d.ts",

--- a/types/common.d.ts
+++ b/types/common.d.ts
@@ -9,6 +9,6 @@ export interface CssLikeObject extends CssProps {
 
 export type TDynamicCss = (css: CssLikeObject) => string;
 export type THyperstyleElement = object;
-export type THyperstyle = (...args) => THyperstyleElement;
+export type THyperstyle = (...args: any[]) => THyperstyleElement;
 export type THyperscriptType = string | Function;
 export type THyperscriptComponent = Function;

--- a/types/nano.d.ts
+++ b/types/nano.d.ts
@@ -137,7 +137,7 @@ export interface NanoOptions {
      * });
      * ```
      */
-    h?: (...args) => any;
+    h?: (...args: any[]) => any;
 
     /**
      * Stylesheet `<sheet>` to be used to inject CSS. If not provided, one will


### PR DESCRIPTION
I want to enable strict mode in the library that uses nano-css, but due to weak typings it fails after disabling skipLibCheck (what is important for providing proper typings). 

My changes in types don't make types of nano-css perfect, but now (tested  with `@phytonmk/nano-css`) it at least doesn't break dependant library type-checking.