### PR TITLE
fix: implement `@jridgewell/sourcemap-codec` instead of deprecated `sourcemap-codec` library

### DIFF
--- a/addon/sourcemaps.js
+++ b/addon/sourcemaps.js
@@ -1,7 +1,7 @@
 'use strict';
 
 var StackTrace = require('stacktrace-js');
-var SourcemapCodec = require('sourcemap-codec');
+var SourcemapCodec = require('@jridgewell/sourcemap-code');
 
 function findStackframe (frames) {
     for (var i = 4; i < frames.length; i++) {

--- a/addon/sourcemaps.js
+++ b/addon/sourcemaps.js
@@ -1,7 +1,7 @@
 'use strict';
 
 var StackTrace = require('stacktrace-js');
-var SourcemapCodec = require('@jridgewell/sourcemap-code');
+var SourcemapCodec = require('@jridgewell/sourcemap-codec');
 
 function findStackframe (frames) {
     for (var i = 4; i < frames.length; i++) {


### PR DESCRIPTION
Fixes https://github.com/streamich/nano-css/issues/260
Fixes https://github.com/streamich/nano-css/issues/263 (duplicated)

This extends https://github.com/streamich/nano-css/pull/261 which did not include the implementation change.